### PR TITLE
Example for file upload to run and simplify API

### DIFF
--- a/alter_completed_runs.py
+++ b/alter_completed_runs.py
@@ -1,7 +1,7 @@
 import argparse
 from getpass import getpass
 from api import Api
-import queries_and_mutations
+import queries
 
 
 def get_runs_from_procedure_id(api: Api, procedure_id: int) -> list:
@@ -16,10 +16,10 @@ def get_runs_from_procedure_id(api: Api, procedure_id: int) -> list:
         list: All run ids associated with given procedure_id
     """
     runs_query = {
-        'query': queries_and_mutations.GET_RUNS,
+        'query': queries.GET_RUNS,
         'variables': {'filters': {'procedureId': {'eq': procedure_id}}}
     }
-    runs = api.send_api_request(runs_query)
+    runs = api.request(runs_query)
     return [run['node']['id'] for run in runs['data']['runs']['edges']]
 
 
@@ -37,13 +37,13 @@ def create_run_step(api: Api, run_id: int, title: str, content: str=None) -> dic
         dict: Fields of newly created step
     """
     create_step = {
-        'query': queries_and_mutations.CREATE_RUN_STEP,
+        'query': queries.CREATE_RUN_STEP,
         'variables': {'input': {
             'title': title,
             'runId': run_id
         }}
     }
-    run_step = api.send_api_request(create_step)
+    run_step = api.request(create_step)
     return run_step['data']['createRunStep']['step']
 
 
@@ -65,7 +65,7 @@ def create_run_step_field(api: Api, run_step_id: int, name: str,
         dict: Values of newly created run step field
     """
     create_field = {
-        'query': queries_and_mutations.CREATE_RUN_STEP_FIELD,
+        'query': queries.CREATE_RUN_STEP_FIELD,
         'variables': {'input': {
             'runStepId': run_step_id,
             'name': name,
@@ -73,7 +73,7 @@ def create_run_step_field(api: Api, run_step_id: int, name: str,
             'required': required
         }}
     }
-    run_step_field = api.send_api_request(create_field)
+    run_step_field = api.request(create_field)
     return run_step_field['data']['createRunStepField']['runStepField']
 
 
@@ -91,14 +91,14 @@ def update_run_step_status(api: Api, run_step: dict, status: str) -> dict:
         dict: Updated fields for run step.
     """
     update_run_step = {
-        'query': queries_and_mutations.UPDATE_RUN_STEP,
+        'query': queries.UPDATE_RUN_STEP,
         'variables': {'input': {
             'id': run_step['id'],
             'status': status,
             'etag': run_step['_etag']
         }}
     }
-    run_step = api.send_api_request(update_run_step)
+    run_step = api.request(update_run_step)
     return run_step['data']['updateRunStep']['runStep']
 
 
@@ -116,14 +116,14 @@ def update_run_step_field_value(api: Api, run_step_field: dict, value) -> dict:
         dict: Updated values for run step field
     """
     update_run_step_field = {
-        'query': queries_and_mutations.UPDATE_RUN_STEP_FIELD_VALUE,
+        'query': queries.UPDATE_RUN_STEP_FIELD_VALUE,
         'variables': {'input': {
             'id': run_step_field['id'],
             'value': value,
             'etag': run_step_field['_etag']
         }}
     }
-    run_step_field = api.send_api_request(update_run_step_field)
+    run_step_field = api.request(update_run_step_field)
     return run_step_field['data']['updateRunStepFieldValue']['runStepField']
 
 

--- a/api.py
+++ b/api.py
@@ -1,5 +1,6 @@
 import os
 import json
+import logging
 import requests
 from urllib.parse import urljoin
 
@@ -53,6 +54,6 @@ class Api(object):
         res = requests.post(urljoin(API_URL, 'graphql'), headers=headers, json=query_info)
         resp_value = res.json()
         if resp_value.get('errors'):
-            print('---AN ERROR OCCURRED IN THE API REQUEST---')
-            print(resp_value)
+            logging.error('---AN ERROR OCCURRED IN THE API REQUEST---')
+            logging.error(resp_value)
         return resp_value

--- a/api.py
+++ b/api.py
@@ -39,7 +39,7 @@ class Api(object):
         return {'Authorization': f'{self.access_token}',
                 'Content-Type': 'application/json'}
 
-    def send_api_request(self, query_info: dict) -> dict:
+    def request(self, query_info: dict) -> dict:
         """
         Send authenticated request to ION GraphQL API.
 
@@ -50,6 +50,9 @@ class Api(object):
             dict: API response from request.
         """
         headers = self._get_headers()
-        req_data = json.dumps(query_info)
-        res = requests.post(urljoin(API_URL, 'graphql'), headers=headers, data=req_data)
-        return json.loads(res.text)
+        res = requests.post(urljoin(API_URL, 'graphql'), headers=headers, json=query_info)
+        resp_value = res.json()
+        if resp_value.get('errors'):
+            print('---AN ERROR OCCURRED IN THE API REQUEST---')
+            print(resp_value)
+        return resp_value

--- a/attach_file_to_run.py
+++ b/attach_file_to_run.py
@@ -1,4 +1,5 @@
-"""This script shows how to get the steps in a run and attach a file to
+"""
+This script shows how to get the steps in a run and attach a file to
 that run. In this example, we are simply uploading the file to the first step
 in the run. In application, you will want to identify the step by title or position
 and upload the file to that step accordingly.
@@ -27,7 +28,7 @@ def upload_file_to_step(api: Api, run_id: int, file_path: str) -> bool:
         file_path (str): The path of the file to upload to the step
 
     Returns:
-        list: Upload succeeded
+        bool: True if the upload succeeded
     """
     # Get the run you want to upload to, so we can find the step to upload to
     r = api.request({

--- a/attach_file_to_run.py
+++ b/attach_file_to_run.py
@@ -1,0 +1,74 @@
+"""This script shows how to get the steps in a run and attach a file to
+that run. In this example, we are simply uploading the file to the first step
+in the run. In application, you will want to identify the step by title or position
+and upload the file to that step accordingly.
+
+The ion file code flow is the following:
+1. Get a pre-signed secure URL from the ion API
+2. Upload file to the S3 location at the secure URL using HTTP PUT
+"""
+
+
+import argparse
+from getpass import getpass
+import os
+import requests
+from api import Api
+import queries
+
+
+def upload_file_to_step(api: Api, run_id: int, file_path: str) -> bool:
+    """
+    Finds a run by the provided run ID and uploads the provided file
+    to the first step of that run.
+
+    Args:
+        api (Api): API instance to send authenticated requests
+        file_path (str): The path of the file to upload to the step
+
+    Returns:
+        list: Upload succeeded
+    """
+    # Get the run you want to upload to, so we can find the step to upload to
+    r = api.request({
+        'query': queries.GET_RUN,
+        'variables': {'id': run_id}
+    })
+    run = r['data']['run']
+    first_step = run['steps'][0]
+
+    # Get the target URL we can upload our file to by using the
+    # createFileAttachment API mutation. We are making the request against
+    # the step's entityId, which is how files are associated to objects in ion
+    attachment_data = {
+        'input': {
+            'entityId': first_step['entityId'],
+            'filename': os.path.basename(file_path)
+            }
+        }
+    upload_request = api.request({
+        'query': queries.CREATE_FILE_ATTACHMENT,
+        'variables': attachment_data
+    })
+    url = upload_request['uploadUrl']
+
+    # Now, let's upload the file!
+    r = requests.put(url, data=open(file_path, 'rb'))
+    return r.ok
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Upload a file to the first step in a run')
+    parser.add_argument('file_path', type=str,
+                        help='The path of the file you want to upload to the step.')
+    parser.add_argument('run_id', type=str,
+                        help='The run to upload the file to.')
+    parser.add_argument('--client_id', type=str, help='Your API client ID')
+    args = parser.parse_args()
+    client_secret = getpass('Client secret: ')
+    if not args.client_id or not client_secret:
+        raise argparse.ArgumentError('Must input client ID and '
+                                     'client secret to run import')
+    api = Api(client_id=args.client_id, client_secret=client_secret)
+    upload_file_to_step(api, args.run_id, args.file_path)

--- a/queries.py
+++ b/queries.py
@@ -10,6 +10,17 @@ query GetRuns($filters: RunsInputFilters, $sort: [RunSortEnum]) {
 }
 '''
 
+GET_RUN = '''
+query GetRun($id: ID!) {
+	run(id: $id) {
+	  id steps {
+	    id
+        position
+        entityId
+	  }
+	}
+}
+'''
 
 CREATE_RUN_STEP = '''
     mutation CreateRunStep($input: CreateRunStepInput!) {
@@ -51,4 +62,12 @@ UPDATE_RUN_STEP = '''
             }
         }
     }
+'''
+
+CREATE_FILE_ATTACHMENT = '''
+mutation CreateFileAttachment($input: CreateFileAttachmentInput!) {
+    createFileAttachment(input: $input) {
+        uploadUrl
+    }
+}
 '''


### PR DESCRIPTION

- Example file for uploading a file to the first step of a run
- Simplify the API
- Display error by printing it when we receive an error from the API